### PR TITLE
Show ExitCode field

### DIFF
--- a/jobinfo
+++ b/jobinfo
@@ -156,6 +156,7 @@ FIELDS = [
         Field("ncpus",               int,        max,          show,  False, f_str,     "Cores"),
         Field("ReqTRES",             gpu_str,    max,          show,  False, f_str,     "GPUs"),
         Field("State",               str_set,    set.union,    show,  False, f_state,   "State"),
+        Field("ExitCode",            str,        keep_first,   show,  False, f_str,     "ExitCode"),
         Field("Submit",              str,        keep_first,   show,  False, f_str,     "Submit"),
         Field("start",               date_str,   min,          show,  False, f_date,    "Start"),
         Field("end",                 str,        time_max,     show,  False, f_date,    "End"),


### PR DESCRIPTION
FIXME: For jobs that haven't completed yet, Slurm reports this value
as '0:0', which I find a bit incorrect (there can't be an _exit code_
if there hasn't been an _exit_ yet, no?).  At the moment the script
reports Slurm's givings verbatim, but perhaps a '--' would've been
better for such cases.