### PR TITLE
Port to python 3 (while keeping compatibility with python 2)

### DIFF
--- a/gnodes
+++ b/gnodes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # gnodes - shows a graphical overview of a Slurm cluster
 #
@@ -74,7 +74,7 @@ except:
                     yield prefix + sub_r
                 else:
                     lo,hi = sub_r.split("-", 1)
-                    for i in xrange(int(lo), int(hi)+1):
+                    for i in range(int(lo), int(hi)+1):
                         yield prefix + str(i).zfill(len(lo))
         else:
             yield p
@@ -199,7 +199,7 @@ def parse_tres(tres):
 def stripped_lines_from_cmd(cmd):
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     for line in p.stdout:
-        yield line.strip()
+        yield line.decode("utf-8").strip()
     p.wait()
 
 def get_output_width(fallback_width):
@@ -299,7 +299,7 @@ def main(partitions, groups, accounts, search_pattern):
     screen_width = get_output_width(80)
     screen_width = int(screen_width) - 1
 
-    for k,g in groupby(sorted(node_meta.iteritems(), key=group_id), key=group_id):
+    for k,g in groupby(sorted(node_meta.items(), key=group_id), key=group_id):
         if len(partitions) > 0:
             if k.partition not in partitions:
                 continue
@@ -334,13 +334,13 @@ def main(partitions, groups, accounts, search_pattern):
             dummy_fields = fields_per_row - fields_in_last_row
             info_fields.extend([" "*max_field_width]*dummy_fields)
             name_patterns.extend([NODENAME_UNMATCHED]*dummy_fields)
-        rows = len(info_fields) / fields_per_row
-        print make_header(
+        rows = int(floor(len(info_fields) / fields_per_row))
+        print(make_header(
                 k.partition, partition_walltimes[k.partition], k.total_cores, k.total_mem, k.gpus,
-                max_field_width, fields_per_row, default_partition)
-        for r in xrange(0, rows):
-            print "| %s |" % " | ".join(pat % s for pat,s in zip(name_patterns, info_fields)[r::rows])
-        print make_footer(max_field_width, fields_per_row)
+                max_field_width, fields_per_row, default_partition))
+        for r in range(0, rows):
+            print("| %s |" % " | ".join(pat % s for pat,s in list(zip(name_patterns, info_fields))[r::rows]))
+        print(make_footer(max_field_width, fields_per_row))
 
 
 if __name__ == "__main__":

--- a/jobinfo
+++ b/jobinfo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # jobinfo - collect job information from slurm in nicely readable format
 #
@@ -6,6 +6,7 @@
 #
 # LICENSE: MIT
 
+from __future__ import print_function
 import math
 import os
 import re
@@ -200,14 +201,14 @@ def get_values(jobid):
     info = subprocess.Popen(['sacct', FORMAT_STR, '--parsable', '--noheader', '-j', jobid], stdout=subprocess.PIPE)
     xs = []
     for line in info.stdout:
-        fields = line.strip().split('|')
+        fields = line.decode("utf-8").strip().split('|')
         # On our cluster the external step is always cancelled for some reason
         # but I don't know if it's something other people might care about
         if fields[0].endswith(".extern"):
             continue
         xs.append([ctor(s) for ctor, s in zip(FIELD_CTORS, fields)])
     if len(xs) == 0:
-        print >>sys.stderr, "No such job"
+        print("No such job", file=sys.stderr)
         sys.exit(1)
     return xs
 
@@ -216,7 +217,7 @@ def get_sstat_values(jobid):
     xs = []
     for line in info.stdout:
         j = 0
-        vals = line.strip().split('|')
+        vals = line.decode("utf-8").strip().split('|')
         x = []
         for f in FIELDS:
             if f.prefer_sstat:
@@ -238,7 +239,7 @@ def main(jobid):
             ys.append(combine(tmp))
     if "PENDING" in meta.State:
         info = subprocess.Popen(['squeue', '--format=%E;%R', '--noheader', '-a', '-j', jobid], stdout=subprocess.PIPE)
-        deps, reason = info.stdout.readline().strip().split(";")
+        deps, reason = info.stdout.readline().decode("utf-8").strip().split(";")
         dependencies = deps
     else:
         dependencies = ""
@@ -249,11 +250,10 @@ def main(jobid):
     for i,(name,parse,comb,show,prefer_sstat,format,desc) in enumerate(FIELDS):
         val = y[i]
         if show:
-            print "%-20s: %s" % (desc, format(val, meta))
+            print("%-20s: %s" % (desc, format(val, meta)))
 
 def usage(pipe):
-    print >>pipe, \
-"""jobinfo - collates job information from the 'sstat', 'sacct' and
+    print("""jobinfo - collates job information from the 'sstat', 'sacct' and
 'squeue' SLURM commands to give a uniform interface for both current
 and historical jobs.
 
@@ -261,7 +261,7 @@ Usage:
     jobinfo <job id>
 
 Report bugs to Anders Halager <aeh@birc.au.dk>
-  or on GitHub (https://github.com/birc-aeh/slurm-utils)"""
+  or on GitHub (https://github.com/birc-aeh/slurm-utils)""", file=pipe)
 
 if __name__ == "__main__":
     if "-h" in sys.argv or "--help" in sys.argv:
@@ -272,7 +272,7 @@ if __name__ == "__main__":
         sys.exit(1)
     jobid = sys.argv[1]
     if len(set(jobid) - set("0123456789_.+")) > 0:
-        print >>sys.stderr, "The argument does not look like a valid job id"
+        print("The argument does not look like a valid job id", file=sys.stderr)
         usage(sys.stderr)
         sys.exit(1)
     main(jobid)


### PR DESCRIPTION
As proposed in #9, this PR ports the code to python 3.

As mentioned in the commit message, most of the work was done by `2to3`. Basic tests work under python 3 and python 2. More tests may be needed.